### PR TITLE
Fix platform paths for Arduino 3.3

### DIFF
--- a/platform.txt
+++ b/platform.txt
@@ -1,18 +1,18 @@
 name=ESP32 Arduino
 version=
 
-tools.xtensa-esp32-elf-gcc.path={runtime.tools.xtensa-esp32-elf-gcc.path}
-tools.xtensa-esp32s2-elf-gcc.path={runtime.tools.xtensa-esp32s2-elf-gcc.path}
-tools.xtensa-esp32s3-elf-gcc.path={runtime.tools.xtensa-esp32s3-elf-gcc.path}
-tools.xtensa-esp-elf-gdb.path={runtime.tools.xtensa-esp-elf-gdb.path}
-tools.riscv32-esp-elf-gcc.path={runtime.tools.riscv32-esp-elf-gcc.path}
-tools.riscv32-esp-elf-gdb.path={runtime.tools.riscv32-esp-elf-gdb.path}
+tools.xtensa-esp32-elf-gcc.path={runtime.platform.path}/tools/xtensa-esp32-elf
+tools.xtensa-esp32s2-elf-gcc.path={runtime.platform.path}/tools/xtensa-esp32s2-elf
+tools.xtensa-esp32s3-elf-gcc.path={runtime.platform.path}/tools/xtensa-esp32s3-elf
+tools.xtensa-esp-elf-gdb.path={runtime.platform.path}/tools/xtensa-esp-elf-gdb
+tools.riscv32-esp-elf-gcc.path={runtime.platform.path}/tools/riscv32-esp-elf
+tools.riscv32-esp-elf-gdb.path={runtime.platform.path}/tools/riscv32-esp-elf-gdb
 
 debug.server.openocd.path={runtime.tools.openocd-esp32.path}/bin/openocd
 debug.server.openocd.scripts_dir={runtime.tools.openocd-esp32.path}/share/openocd/scripts/
 debug.server.openocd.scripts_dir.windows={runtime.tools.openocd-esp32.path}\share\openocd\scripts\
 
-tools.esptool_py.path={runtime.tools.esptool_py.path}
+tools.esptool_py.path={runtime.platform.path}/tools/esptool
 tools.esptool_py.cmd=esptool
 tools.esptool_py.cmd.linux=esptool.py
 tools.esptool_py.cmd.windows=esptool.exe


### PR DESCRIPTION
## Summary
- fix `platform.txt` tool paths to match Arduino-ESP32 v3.3 layout

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_68507b98f7f8832f8acfb100d22a2d1c